### PR TITLE
chore: changed variable name as referencing the same on L79

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ impl<'a> WebviewWindowExt for WebviewWindow {
 
         let win2 = self.clone();
 
-        self.listen("decorum-page-load", move |_event| {
+        self.listen("decorum-page-load", move |event| {
             // println!("decorum-page-load event received")
 
             // Create a transparent draggable area for the titlebar


### PR DESCRIPTION
changed variable name from `_event` to `event` as referencing the same on L79