### PR TITLE
Add KDE icon fallback support and default SVG icons for Linux

### DIFF
--- a/src/js/linux-controls.js
+++ b/src/js/linux-controls.js
@@ -58,6 +58,7 @@ document.addEventListener("DOMContentLoaded", () => {
       const btn = document.createElement("button");
       btn.id = "decorum-tb-" + id;
       btn.classList.add("decorum-tb-btn");
+      let timer;
 
       switch (id) {
         case "minimize":


### PR DESCRIPTION
## Changes
- Added KDE icon name fallback support for Linux window controls
- Added SVG fallback icons when both GNOME and KDE icons are not found
- Fixed undefined `timer` variable in `linux-controls.js` causing console errors on window minimize

Before the fallback icons:
![image](https://github.com/user-attachments/assets/4fdbaa61-f053-4437-881d-1f6607108230)

After:
![image](https://github.com/user-attachments/assets/dbce1ffd-1674-4a1c-bf40-a87197f53393)

This was tested on EndeavourOS with KDE (Wayland). But with the fallback SVG, it should work on all Desktop Environments
