### PR TITLE
feat: add create_custom_titlebar and impored the css of buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ dist-js
 dist
 
 examples/tauri-app/pnpm-lock.yaml
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -56,17 +56,24 @@ fn main() {
 			let main_window = app.get_webview_window("main").unwrap();
 			main_window.create_overlay_titlebar().unwrap();
 
+			// If you want to use the titlebar you made via a div, you can do this:
+			// Firstly, you should add data-tauri-decorum-tb selector to the header div.
+			// Such as: `<div data-tauri-decorum-tb>...</div>`
+			// Then you can use this method to set the titlebar to that div.
+			main_window.create_custom_titlebar().unwrap();
+			// Additionally, you should custom buttons with css.
+
 			// Some macOS-specific helpers
 			#[cfg(target_os = "macos")] {
 				// Set a custom inset to the traffic lights
 				main_window.set_traffic_lights_inset(12.0, 16.0).unwrap();
 
 				// Make window transparent without privateApi
-				main_window.make_transparent().unwrap()
+				main_window.make_transparent().unwrap();
 
 				// Set window level
 				// NSWindowLevel: https://developer.apple.com/documentation/appkit/nswindowlevel
-				main_window.set_window_level(25).unwrap()
+				main_window.set_window_level(25).unwrap();
 			}
 
 			Ok(())

--- a/permissions/autogenerated/reference.md
+++ b/permissions/autogenerated/reference.md
@@ -1,5 +1,5 @@
 
-## Permission Table 
+## Permission Table
 
 <table>
 <tr>

--- a/permissions/schemas/schema.json
+++ b/permissions/schemas/schema.json
@@ -49,7 +49,7 @@
           "minimum": 1.0
         },
         "description": {
-          "description": "Human-readable description of what the permission does. Tauri convention is to use <h4> headings in markdown content for Tauri documentation generation purposes.",
+          "description": "Human-readable description of what the permission does. Tauri convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
           "type": [
             "string",
             "null"
@@ -111,7 +111,7 @@
           "type": "string"
         },
         "description": {
-          "description": "Human-readable description of what the permission does. Tauri internal convention is to use <h4> headings in markdown content for Tauri documentation generation purposes.",
+          "description": "Human-readable description of what the permission does. Tauri internal convention is to use `<h4>` headings in markdown content for Tauri documentation generation purposes.",
           "type": [
             "string",
             "null"

--- a/src/js/controls.js
+++ b/src/js/controls.js
@@ -140,7 +140,17 @@ document.addEventListener("DOMContentLoaded", () => {
 			}
 
 			#decorum-tb-close:hover {
-				background-color: rgba(255,0,0,0.7) !important;
+				background-color: #C42B1C !important;
+				color: white;
+			}
+
+			@media (prefers-color-scheme: dark) {
+				.decorum-tb-btn {
+					color: white;
+				}
+				.decorum-tb-btn:hover {
+					background-color: rgba(255, 255, 255, 0.2);
+				}
 			}
 		`;
 	});


### PR DESCRIPTION
The `main_window.create_custom_titlebar()` function could let users to custom the titlebar with adding `data-tauri-decorum-tb` to the header div. 
I made this change because when I add `data-tauri-decorum-tb` to the header div I wrote myself with Vue, the titlebar.js always creates the other div I don't need.
And I added some css to the buttons, which could let them change the colors when the theme change to dark.