### PR TITLE
feat: add webview-only transparency support for macOS

### DIFF
--- a/examples/tauri-app/src-tauri/src/main.rs
+++ b/examples/tauri-app/src-tauri/src/main.rs
@@ -15,7 +15,11 @@ fn main() {
             main_window.create_overlay_titlebar().unwrap();
 
             #[cfg(target_os = "macos")]
-            main_window.set_traffic_lights_inset(16.0, 20.0).unwrap();
+            {
+                main_window.set_traffic_lights_inset(20.0, 24.0).unwrap();
+                // Make only the webview transparent (window remains opaque)
+                main_window.make_webview_transparent().unwrap();
+            }
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/examples/tauri-app/src/App.tsx
+++ b/examples/tauri-app/src/App.tsx
@@ -9,6 +9,12 @@ function App() {
 				</a>
 			</div>
 			<p>Click on the Tauri logo to learn more.</p>
+			
+			<div className="transparent-demo">
+				<h2>Webview Transparency Demo</h2>
+				<p>This area demonstrates webview transparency.</p>
+				<p>The webview background is transparent, but the window remains opaque.</p>
+			</div>
 		</div>
 	);
 }

--- a/examples/tauri-app/src/styles.css
+++ b/examples/tauri-app/src/styles.css
@@ -5,7 +5,7 @@
 	font-weight: 400;
 
 	color: #222222;
-	background-color: #f6f6f6;
+	background-color: transparent;
 
 	font-synthesis: none;
 	text-rendering: optimizeLegibility;
@@ -88,11 +88,28 @@ button {
 	margin-right: 5px;
 }
 
+.transparent-demo {
+	margin-top: 2rem;
+	padding: 1rem;
+	border: 2px dashed #ccc;
+	border-radius: 8px;
+	background-color: rgba(255, 255, 255, 0.8);
+}
+
+.transparent-demo h2 {
+	color: #333;
+	margin-bottom: 0.5rem;
+}
+
+.transparent-demo p {
+	color: #666;
+	margin: 0.5rem 0;
+}
+
 @media (prefers-color-scheme: dark) {
 	:root {
 		color: #f6f6f6;
-		background-image: linear-gradient(180deg, #350042 0%, #1f003b 100%);
-		background-size: cover;
+		background-color: transparent;
 	}
 
 	body {
@@ -112,5 +129,18 @@ button {
 	}
 	button:active {
 		background-color: #0f0f0f69;
+	}
+
+	.transparent-demo {
+		background-color: rgba(0, 0, 0, 0.4);
+		border-color: #666;
+	}
+
+	.transparent-demo h2 {
+		color: #f6f6f6;
+	}
+
+	.transparent-demo p {
+		color: #ccc;
 	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub trait WebviewWindowExt {
     #[cfg(target_os = "macos")]
     fn make_transparent(&self) -> Result<&WebviewWindow, Error>;
     #[cfg(target_os = "macos")]
+    fn make_webview_transparent(&self) -> Result<&WebviewWindow, Error>;
+    #[cfg(target_os = "macos")]
     fn set_window_level(&self, level: u32) -> Result<&WebviewWindow, Error>;
 }
 
@@ -199,6 +201,26 @@ impl<'a> WebviewWindowExt for WebviewWindow {
             }
             Ok(win)
         })
+    }
+
+    /// Set only the webview background to transparent (window remains opaque).
+    /// This allows for transparent webview content while maintaining window decorations.
+    #[cfg(target_os = "macos")]
+    fn make_webview_transparent(&self) -> Result<&WebviewWindow, Error> {
+        use cocoa::{
+            base::{id, nil},
+            foundation::NSString,
+        };
+
+        // Make only webview background transparent
+        self.with_webview(|webview| unsafe {
+            let id = webview.inner() as *mut objc::runtime::Object;
+            let no: id = msg_send![class!(NSNumber), numberWithBool:0];
+            let _: id =
+                msg_send![id, setValue:no forKey: NSString::alloc(nil).init_str("drawsBackground")];
+        })?;
+
+        Ok(self)
     }
 
     /// Set the window level.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ impl<'a> WebviewWindowExt for WebviewWindow {
             let id = webview.inner() as *mut objc::runtime::Object;
             let no: id = msg_send![class!(NSNumber), numberWithBool:0];
             let _: id =
-                msg_send![id, setValue:no forKey: NSString::alloc(nil).init_str("drawsBackground")];
+                msg_send![id, setValue:no forKey: NSString::from_str("drawsBackground")];
         })?;
 
         Ok(self)


### PR DESCRIPTION
Add make_webview_transparent() method that makes only the webview background transparent while keeping the window opaque, providing more granular control over transparency.

- Add make_webview_transparent() method to WebviewWindowExt trait
- Implement webview-only transparency using NSView drawsBackground property
- Update example app to demonstrate webview transparency
- Add transparent CSS styling to showcase the effect

🤖 Generated with [Claude Code](https://claude.ai/code)